### PR TITLE
Model lists as Lists of NonNull elements

### DIFF
--- a/src/backref-types.js
+++ b/src/backref-types.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const _get = require('lodash.get');
-const {GraphQLObjectType, GraphQLList} = require('graphql');
+const {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLList
+} = require('graphql');
 
 module.exports = createBackrefsType;
 
@@ -24,7 +28,7 @@ function prepareBackrefsFields (ct, ctIdToType) {
 
 function createBackrefFieldConfig (backref, Type) {
   return {
-    type: new GraphQLList(Type),
+    type: new GraphQLList(new GraphQLNonNull(Type)),
     resolve: (entryId, _, ctx) => {
       return ctx.entryLoader.queryAll(backref.ctId)
       .then(entries => filterEntries(entries, backref.fieldId, entryId));

--- a/src/field-config.js
+++ b/src/field-config.js
@@ -3,6 +3,7 @@
 const _get = require('lodash.get');
 
 const {
+  GraphQLNonNull,
   GraphQLString,
   GraphQLInt,
   GraphQLFloat,
@@ -49,7 +50,7 @@ function createObjectFieldConfig (field) {
 }
 
 function createArrayOfStringsFieldConfig (field) {
-  return createFieldConfig(new GraphQLList(GraphQLString), field);
+  return createFieldConfig(new GraphQLList(new GraphQLNonNull(GraphQLString)), field);
 }
 
 function createAssetFieldConfig (field) {
@@ -57,7 +58,7 @@ function createAssetFieldConfig (field) {
 }
 
 function createArrayOfAssetsFieldConfig (field) {
-  return createFieldConfig(new GraphQLList(AssetType), field, (links, ctx) => {
+  return createFieldConfig(new GraphQLList(new GraphQLNonNull(AssetType)), field, (links, ctx) => {
     if (Array.isArray(links)) {
       return links.map(link => getAsset(link, ctx)).filter(isObject);
     }
@@ -81,7 +82,7 @@ function createEntryFieldConfig (field, ctIdToType) {
 }
 
 function createArrayOfEntriesFieldConfig (field, ctIdToType) {
-  const Type = new GraphQLList(typeFor(field, ctIdToType));
+  const Type = new GraphQLList(new GraphQLNonNull(typeFor(field, ctIdToType)));
 
   return createFieldConfig(Type, field, (links, ctx) => {
     if (Array.isArray(links)) {

--- a/src/schema.js
+++ b/src/schema.js
@@ -4,6 +4,7 @@ const _get = require('lodash.get');
 
 const {
   GraphQLSchema,
+  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLList,
   GraphQLString,
@@ -68,7 +69,7 @@ function createQueryFields (spaceGraph) {
     };
 
     acc[ct.names.collectionField] = {
-      type: new GraphQLList(Type),
+      type: new GraphQLList(new GraphQLNonNull(Type)),
       args: {
         q: {type: GraphQLString},
         skip: {type: GraphQLInt},

--- a/test/field-config.test.js
+++ b/test/field-config.test.js
@@ -3,6 +3,7 @@
 const test = require('tape');
 
 const {
+  GraphQLNonNull,
   GraphQLString,
   GraphQLInt,
   GraphQLFloat,
@@ -26,6 +27,10 @@ const ctx = {
     getMany: ids => Promise.resolve(ids.map(id => entities.entry[id]))
   }
 };
+
+function isNonNullType(type) {
+  return type instanceof GraphQLNonNull;
+}
 
 test('field-config: simple types', function (t) {
   const tests = [
@@ -79,6 +84,7 @@ test('field-config: array of strings', function (t) {
   const config = map['Array<String>']({id: 'test'});
   t.ok(config.type instanceof GraphQLList);
   t.equal(getNamedType(config.type), GraphQLString);
+  t.ok(isNonNullType(config.type.ofType));
   t.equal(config.resolve({fields: {}}), undefined);
 
   [[], ['x'], ['x', 'y'], null, undefined].forEach(val => {
@@ -141,6 +147,7 @@ test('field-config: arrays of links', function (t) {
   [[assetConfig, AssetType], [entryConfig, EntryType]].forEach(([config, Type]) => {
     t.ok(config.type instanceof GraphQLList);
     t.equal(getNamedType(config.type), Type);
+    t.ok(isNonNullType(config.type.ofType));
     t.equal(config.resolve({fields: {}}), undefined);
     t.equal(config.resolve({fields: {test: null}}), undefined);
     t.deepEqual(config.resolve({fields: {test: []}}, null, ctx), []);


### PR DESCRIPTION
Presently, a field that is marked as a List is represented in the schema as a List of Nullable elements, but it seems that the elements themselves can be marked NonNull?

Concretely, this turns a list-of-strings field from `[String]` to `[String!]`, maintaining nullability of the overall value but marking each element of the array as not nullable.

Developing against a schema with nullable list elements in a null-safe language (in this case Swift) is not much fun. ☹️ 