### PR TITLE
feature: add width & height to the asset type

### DIFF
--- a/src/base-types.js
+++ b/src/base-types.js
@@ -51,6 +51,14 @@ const AssetType = new GraphQLObjectType({
     url: {
       type: GraphQLString,
       resolve: asset => _get(asset, ['fields', 'file', 'url'])
+    },
+    width: {
+      type: GraphQLInt,
+      resolve: asset => _get(asset, [ 'fields', 'file', 'details', 'image', 'width' ])
+    },
+    height: {
+      type: GraphQLInt,
+      resolve: asset => _get(asset, [ 'fields', 'file', 'details', 'image', 'height' ])
     }
   }
 });

--- a/test/base-types.test.js
+++ b/test/base-types.test.js
@@ -44,10 +44,10 @@ test('base-types: asset', function (t) {
       fields: {
         title: 'xyz',
         description: 'asset desc',
-        file: {url: 'http://some-url'}
+        file: {url: 'http://some-url', details: {image: {width: 800, height: 600}}}
       }
     }),
-    '{ test { sys { id createdAt updatedAt } title description url } }'
+    '{ test { sys { id createdAt updatedAt } title description url width height } }'
   ).then(res => {
     t.deepEqual(res.data.test, {
       sys: {
@@ -57,7 +57,9 @@ test('base-types: asset', function (t) {
       },
       title: 'xyz',
       description: 'asset desc',
-      url: 'http://some-url'
+      url: 'http://some-url',
+      width: 800,
+      height: 600
     });
     t.equal(res.errors, undefined);
   });


### PR DESCRIPTION
We'd like to have the image dimensions available in GraphQL.

This PR will add the flattened width and height fields to the Asset type. In case of PDFs and other unsupported file types, they'll be `null`.