### PR TITLE
Option to export non-nullable fields

### DIFF
--- a/src/field-config.js
+++ b/src/field-config.js
@@ -3,6 +3,7 @@
 const _get = require('lodash.get');
 
 const {
+  GraphQLNonNull,
   GraphQLString,
   GraphQLInt,
   GraphQLFloat,
@@ -34,7 +35,7 @@ module.exports = {
 
 function createFieldConfig (Type, field, resolveFn) {
   return {
-    type: Type,
+    type: field.required ? new GraphQLNonNull(Type) : Type,
     resolve: (entity, _, ctx) => {
       const fieldValue = _get(entity, ['fields', field.id], NOTHING);
       if (fieldValue !== NOTHING) {

--- a/src/prepare-space-graph.js
+++ b/src/prepare-space-graph.js
@@ -81,6 +81,7 @@ function field (f) {
 
   return {
     id: f.id,
+    required: f.required,
     type: type(f),
     linkedCt: linkedCt(f)
   };

--- a/src/prepare-space-graph.js
+++ b/src/prepare-space-graph.js
@@ -32,7 +32,7 @@ const SIMPLE_FIELD_TYPE_MAPPING = {
 module.exports = prepareSpaceGraph;
 
 function prepareSpaceGraph (cts, options) {
-  return addBackrefs(createSpaceGraph(cts, options));
+  return addBackrefs(createSpaceGraph(cts, options || {}));
 }
 
 function createSpaceGraph (cts, options) {

--- a/src/prepare-space-graph.js
+++ b/src/prepare-space-graph.js
@@ -31,18 +31,18 @@ const SIMPLE_FIELD_TYPE_MAPPING = {
 
 module.exports = prepareSpaceGraph;
 
-function prepareSpaceGraph (cts) {
-  return addBackrefs(createSpaceGraph(cts));
+function prepareSpaceGraph (cts, options) {
+  return addBackrefs(createSpaceGraph(cts, options));
 }
 
-function createSpaceGraph (cts) {
+function createSpaceGraph (cts, options) {
   const accumulatedNames = {};
 
   return cts.map(ct => ({
     id: ct.sys.id,
     names: names(ct.name, accumulatedNames),
     fields: ct.fields.reduce((acc, f) => {
-      return f.omitted ? acc : acc.concat([field(f)]);
+      return f.omitted ? acc : acc.concat([field(f, options.enforceRequiredFields)]);
     }, [])
   }));
 }
@@ -72,7 +72,7 @@ function checkForConflicts (names, accumulatedNames) {
   return names;
 }
 
-function field (f) {
+function field (f, enforceRequiredFields) {
   ['sys', '_backrefs'].forEach(id => {
     if (f.id === id) {
       throw new Error(`Fields named "${id}" are unsupported`);
@@ -81,7 +81,7 @@ function field (f) {
 
   return {
     id: f.id,
-    required: f.required,
+    required: enforceRequiredFields && f.required,
     type: type(f),
     linkedCt: linkedCt(f)
   };


### PR DESCRIPTION
### Feature description

This add an option `enforceRequiredField` to `prepareSpaceGraph` that will generate non-nullable field (for instance `String!`) when a content type is marked as required in contenful.

This option is disabled by default as Contenful does not make a strong guarantee that a required field is non-nullable (this was in fact the default behaviour before it was fixed as part of #5 ).

### Motivation

In the context of the project I am currently working on, we have a process to enforce the non-nullability of the content types.

We are also using flow types in our frontend code, and the flow definitions of the graphql queries are generated from the graphql schema by [`apollo-codegen`](https://github.com/apollographql/apollo-codegen).

Without this option enabled, all fields but sys fields are considered nullable, and as a result flow is emitting a huge amount of false alarms for potential null reference errors, which make the use of flow in that project practically useless.