### PR TITLE
Remove caching logic from http client

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -13,8 +13,7 @@ function createClient (config) {
     base: config.base || '',
     headers: config.headers || {},
     defaultParams: config.defaultParams || {},
-    timeline: config.timeline || [],
-    cache: config.cache || {}
+    timeline: config.timeline || []
   };
 
   return {
@@ -30,26 +29,22 @@ function get (url, params, opts) {
     url = `${url}?${sortedQS}`;
   }
 
-  const {base, headers, timeline, cache} = opts;
-  const cached = cache[url];
-  if (cached) {
-    return cached;
-  }
+  const {base, headers, timeline} = opts;
 
   const httpCall = {url, start: Date.now()};
   timeline.push(httpCall);
 
-  cache[url] = fetch(
+  const res = fetch(
     base + url,
     {headers: Object.assign({}, getUserAgent(), headers)}
   )
-  .then(checkStatus)
-  .then(res => {
-    httpCall.duration = Date.now()-httpCall.start;
-    return res.json();
-  });
+    .then(checkStatus)
+    .then(res => {
+      httpCall.duration = Date.now()-httpCall.start;
+      return res.json();
+    });
 
-  return cache[url];
+  return res;
 }
 
 function checkStatus (res) {

--- a/src/http-client.js
+++ b/src/http-client.js
@@ -38,11 +38,11 @@ function get (url, params, opts) {
     base + url,
     {headers: Object.assign({}, getUserAgent(), headers)}
   )
-    .then(checkStatus)
-    .then(res => {
-      httpCall.duration = Date.now()-httpCall.start;
-      return res.json();
-    });
+  .then(checkStatus)
+  .then(res => {
+    httpCall.duration = Date.now()-httpCall.start;
+    return res.json();
+  });
 
   return res;
 }

--- a/test/http-client.test.js
+++ b/test/http-client.test.js
@@ -85,7 +85,7 @@ test('http-client: non 2xx response codes', function (t) {
   });
 });
 
-test('http-client: reuses already fired requests', function (t) {
+test('http-client: does *not* reuse already fired requests', function (t) {
   t.plan(2);
   const {fetch, http} = prepare();
 
@@ -94,8 +94,8 @@ test('http-client: reuses already fired requests', function (t) {
 
   Promise.all([p1, http.get('/two'), p2])
   .then(() => {
-    t.equal(p1, p2);
-    t.equal(fetch.callCount, 2);
+    t.notEqual(p1, p2);
+    t.equal(fetch.callCount, 3);
   });
 });
 
@@ -108,10 +108,10 @@ test('http-client: sorts parameters', function (t) {
 
   Promise.all([p1, http.get('/two', {omega: true, alfa: false}), p2])
   .then(() => {
-    t.equal(p1, p2);
-    t.equal(fetch.callCount, 2);
+    t.notEqual(p1, p2);
+    t.equal(fetch.callCount, 3);
     t.equal(fetch.firstCall.args[0], 'http://test.com/one?a=456&z=123');
-    t.equal(fetch.secondCall.args[0], 'http://test.com/two?alfa=false&omega=true');
+    t.equal(fetch.thirdCall.args[0], 'http://test.com/two?alfa=false&omega=true');
   });
 });
 


### PR DESCRIPTION
With the caching logic present, the updated data is only received upon the very first request, but every subsequent request will fetch stale data because the request has been memoized.