### PR TITLE
Add error message for missing context

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -13,6 +13,7 @@ const {
 const {EntrySysType, EntryType, IDType, CollectionMetaType} = require('./base-types.js');
 const typeFieldConfigMap = require('./field-config.js');
 const createBackrefsType = require('./backref-types.js');
+const entryLoaderError = '\'entryLoader\' must be defined on the context.';
 
 module.exports = {
   createSchema,
@@ -64,7 +65,12 @@ function createQueryFields (spaceGraph) {
     acc[ct.names.field] = {
       type: Type,
       args: {id: {type: IDType}},
-      resolve: (_, args, ctx) => ctx.entryLoader.get(args.id, ct.id)
+      resolve: (_, args, ctx) => {
+        if (!ctx || !ctx.entryLoader) {
+          throw new TypeError(entryLoaderError);
+        }
+        return ctx.entryLoader.get(args.id, ct.id);
+      }
     };
 
     acc[ct.names.collectionField] = {
@@ -74,13 +80,23 @@ function createQueryFields (spaceGraph) {
         skip: {type: GraphQLInt},
         limit: {type: GraphQLInt}
       },
-      resolve: (_, args, ctx) => ctx.entryLoader.query(ct.id, args)
+      resolve: (_, args, ctx) => {
+        if (!ctx || !ctx.entryLoader) {
+          throw new TypeError(entryLoaderError);
+        }
+        return ctx.entryLoader.query(ct.id, args);
+      }
     };
 
     acc[`_${ct.names.collectionField}Meta`] = {
       type: CollectionMetaType,
       args: {q: {type: GraphQLString}},
-      resolve: (_, args, ctx) => ctx.entryLoader.count(ct.id, args).then(count => ({count}))
+      resolve: (_, args, ctx) => {
+        if (!ctx || !ctx.entryLoader) {
+          throw new TypeError(entryLoaderError);
+        }
+        return ctx.entryLoader.count(ct.id, args).then(count => ({count}));
+      }
     };
 
     return acc;

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -159,3 +159,17 @@ test('schema: producting query fields', function (t) {
 
   t.end();
 });
+
+test('schema: throws an error without entryLoader', function(t) {
+  const queryFields = createQueryFields([postct]);
+
+  t.throws(function() {
+    queryFields.post.resolve();
+  }, TypeError, 'throws without a context');
+
+  t.throws(function() {
+    queryFields.post.resolve(null, null, {});
+  }, TypeError, 'throws without entryLoader on context');
+
+  t.end();
+});


### PR DESCRIPTION
## Description
I was running into a misconfigured version of a client - the result was a misconfigured client, but the error messages were unclear how to fix the problem.  Adding a clearer `TypeError` should help anyone in the future to debug the same problem.

Fixes https://github.com/contentful-labs/cf-graphql/issues/56